### PR TITLE
add URLs to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,8 @@ Description: A framework that boosts the imputation of 'missForest' by Stekhoven
              3. Supports multiple initializations methods.
              4. Supports early stopping that prohibits unnecessary iterations.
 License: GPL-2
+URL: https://github.com/catstats/misspi
+BugReports: https://github.com/catstats/misspi/issues
 Encoding: UTF-8
 LazyData: true
 Imports: lightgbm, doParallel, doSNOW, foreach, ggplot2, glmnet, SIS, plotly


### PR DESCRIPTION
👋🏻 Hi, I'm one of the maintainers of `{lightgbm}` (https://github.com/microsoft/LightGBM).

I'm working on adding some tests there that check that changes to `{lightgbm}` don't break any libraries that depend on it (https://github.com/microsoft/LightGBM/pull/6734). I might want to propose some changes to `{misspi}` as a result of looking into test failures from that effort. I did not realize that this project was being developed on GitHub, because there is no mention of this repo in the docs at https://cran.r-project.org/web/packages/misspi/index.html.

This proposes adding links to `DESCRIPTION`, which will show up on the project's CRAN homepage. Example from https://cran.r-project.org/web/packages/lightgbm/index.html:

<img width="852" alt="Screenshot 2024-12-07 at 11 48 54 PM" src="https://github.com/user-attachments/assets/b9cfa76a-c0d8-4c28-af26-c9a8af45ff11">

That's a result of similar `DESCRIPTION` content in `{lightgbm}`: https://github.com/microsoft/LightGBM/blob/d4d6c87db02a146ac6dc04b00f538e02a3b22250/R-package/DESCRIPTION#L42-L43

Thanks for your time and consideration, and for using LightGBM!